### PR TITLE
Fix SoftwareVersion::Version#sv

### DIFF
--- a/lib/software_version/version.rb
+++ b/lib/software_version/version.rb
@@ -84,7 +84,7 @@ module SoftwareVersion
 
     # Parse the version to get the major, minor and patch parts
     def sv
-      @sv ||= version.scan(/(?:\d+|\D+)/)
+      @sv ||= version.scan(/(?:\d+|[a-zA-Z]+)/)
     end
 
     def version_split_digits(part)


### PR DESCRIPTION
There was a bug in the #sv method which is used to get the major/minor/patch part of a version