### PR TITLE
Fix method patch

### DIFF
--- a/lib/software_version/version.rb
+++ b/lib/software_version/version.rb
@@ -50,7 +50,7 @@ module SoftwareVersion
     end
 
     def patch
-      sv[2]
+      sv[2..].join unless sv[2..].blank?
     end
 
     private

--- a/spec/software_version/common_spec.rb
+++ b/spec/software_version/common_spec.rb
@@ -228,6 +228,14 @@ module SoftwareVersion
             expect(subject).to eq nil
           end
         end
+
+        context 'with 19.1R2 parts' do
+          let(:version) { Version.new('19.1R2') }
+
+          it 'returns R2' do
+            expect(subject).to eq 'R2'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
For versions like `20.4R3` we were detecting `R` instead of `R3` as patch