### PR TITLE
Ease the creation of software versions

### DIFF
--- a/lib/software_version.rb
+++ b/lib/software_version.rb
@@ -2,3 +2,8 @@ require 'software_version/version'
 
 module SoftwareVersion
 end
+
+# Convert the argument into a SoftwareVersion::Version.
+def SoftwareVersion(version)
+  SoftwareVersion::Version(version)
+end

--- a/lib/software_version/version.rb
+++ b/lib/software_version/version.rb
@@ -158,4 +158,10 @@ module SoftwareVersion
       false
     end
   end
+
+  # Convert the argument to a Version, unless it already is one.
+  def Version(version)
+    version.is_a?(Version) ? version : Version.new(version)
+  end
+  module_function :Version
 end

--- a/spec/software_version/common_spec.rb
+++ b/spec/software_version/common_spec.rb
@@ -90,6 +90,18 @@ module SoftwareVersion
       expect(a > b).to be true
     end
 
+    describe 'conversion' do
+      it 'converts its argument to a version' do
+        expect(SoftwareVersion::Version('1.0')).to be_a Version
+        expect(SoftwareVersion::Version(Version.new('1.0'))).to be_a Version
+      end
+
+      it 'is aliased in the main module' do
+        expect(SoftwareVersion('1.0')).to be_a Version
+        expect(SoftwareVersion(Version.new('1.0'))).to be_a Version
+      end
+    end
+
     describe '#major' do
       subject { version.major }
 


### PR DESCRIPTION
Rather than writing `SoftwareVersion::Version.new('1.0')`, users will be able to write `SoftwareVersion('1.0')` instead.