### PR TITLE
Optimize the lexer

### DIFF
--- a/spec/software_version/common_spec.rb
+++ b/spec/software_version/common_spec.rb
@@ -273,68 +273,68 @@ module SoftwareVersion
     describe '#tokens' do
       it 'handles epoch' do
         expect(described_class.new('1:2.3').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::EPOCH, 1),
-          described_class::Token.new(described_class::Token::NUMBER, 2),
-          described_class::Token.new(described_class::Token::NUMBER, 3),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::EPOCH, 1],
+          [described_class::Token::NUMBER, 2],
+          [described_class::Token::NUMBER, 3],
+          [described_class::Token::EOV, nil]
         ]
       end
 
       it 'drops useless zeros' do
         expect(described_class.new('1.0.0beta').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::PREVERSION, 'beta'),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::PREVERSION, 'beta'],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1.0.0.beta').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::PREVERSION, 'beta'),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::PREVERSION, 'beta'],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1.0.1').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::NUMBER, 0),
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::NUMBER, 0],
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1.0u1').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::NUMBER, 0),
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::NUMBER, 0],
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::EOV, nil]
         ]
       end
 
       it 'drops fancy number separators' do
         expect(described_class.new('1u2').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::NUMBER, 2),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::NUMBER, 2],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1u').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::WORD, 'u'),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::WORD, 'u'],
+          [described_class::Token::EOV, nil]
         ]
       end
 
       it 'handles abbreviated pre-versions' do
         expect(described_class.new('1b2').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::PREVERSION, 'b'),
-          described_class::Token.new(described_class::Token::NUMBER, 2),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::PREVERSION, 'b'],
+          [described_class::Token::NUMBER, 2],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1b.2').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::WORD, 'b'),
-          described_class::Token.new(described_class::Token::NUMBER, 2),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::WORD, 'b'],
+          [described_class::Token::NUMBER, 2],
+          [described_class::Token::EOV, nil]
         ]
         expect(described_class.new('1b').send(:tokens)).to eq [
-          described_class::Token.new(described_class::Token::NUMBER, 1),
-          described_class::Token.new(described_class::Token::WORD, 'b'),
-          described_class::Token.new(described_class::Token::EOV, nil)
+          [described_class::Token::NUMBER, 1],
+          [described_class::Token::WORD, 'b'],
+          [described_class::Token::EOV, nil]
         ]
       end
     end


### PR DESCRIPTION
String#chunk is actually pretty slow, and makes us call #join afterwards. Implementing our own loop with #each_char is more verbose, but makes the benchmark 20% faster.

The overhead caused by the Struct slows down the benchmark by about 10%. Arrays are a bit less readable, but the code remains clear enough.

Cumulated, the benchmark becomes 30% faster. The lexer remains the slowest part of the parsing though.