### PR TITLE
Define JSON serialization

### DIFF
--- a/lib/software_version/version.rb
+++ b/lib/software_version/version.rb
@@ -26,6 +26,10 @@ module SoftwareVersion
       to_s
     end
 
+    def as_json
+      to_s
+    end
+
     def epoch
       if !tokens.empty? && tokens[0][0] == Token::EPOCH
         tokens[0][1]


### PR DESCRIPTION
When a Hash or any object containing a SoftwareVersion::Version is serialized into JSON from a Rails application, the result is currently `{ "v" => @v }`. Returning the version string would be a more intuitive serialization and avoids explicitly casting the Version into a String.