### PR TITLE
Treat commas and spaces as equivalent to dots and underscores

### DIFF
--- a/lib/software_version/version.rb
+++ b/lib/software_version/version.rb
@@ -97,12 +97,14 @@ module SoftwareVersion
     # same type are grouped together to form a single unit.
     CHARACTERS_TOKEN = {
         '.' => Token::DOT,
+        ',' => Token::DOT,
         '~' => Token::TILDE,
         '+' => Token::PLUS,
         '-' => Token::DASH,
         ':' => Token::COLON,
         '^' => Token::CARET,
         '_' => Token::UNDERSCORE,
+        ' ' => Token::UNDERSCORE,
         '0' => Token::NUMBER,
         '1' => Token::NUMBER,
         '2' => Token::NUMBER,

--- a/spec/software_version/common_spec.rb
+++ b/spec/software_version/common_spec.rb
@@ -117,6 +117,11 @@ module SoftwareVersion
       end
     end
 
+    specify 'character equivalence' do
+      expect(Version.new('1,1')).to eq '1.1'
+      expect(Version.new('1 1')).to eq '1_1'
+    end
+
     specify '#epoch' do
       expect(Version.new('').epoch).to eq 0
       expect(Version.new('1.0').epoch).to eq 0


### PR DESCRIPTION
Some vendors use them interchangeably, and it feels intuitive. To begin with, they act as lexical separators rather than semantic tokens so their exact meaning is irrelevant.